### PR TITLE
target binary by name (for upcoming release)

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,11 +39,12 @@ class RustPlugin {
     this.serverless.service.package.excludeDevDependencies = false;
   }
 
-  runDocker(funcArgs, cargoPackage) {
+  runDocker(funcArgs, cargoPackage, binary) {
     const defaultArgs = [
       'run',
       '--rm',
       '-t',
+      '-e', `BIN=${binary}`,
       `-v`, `${this.servicePath}:/code`,
       `-v`, `${process.env['HOME']}/.cargo/registry:/root/.cargo/registry`,
       `-v`, `${process.env['HOME']}/.cargo/git:/root/.cargo/git`,
@@ -100,7 +101,7 @@ class RustPlugin {
         binary = cargoPackage;
       }
       this.serverless.cli.log(`Building native Rust ${func.handler} func...`);
-      const res = this.runDocker(func.rust, cargoPackage);
+      const res = this.runDocker(func.rust, cargoPackage, binary);
       if (res.error || res.status > 0) {
         this.serverless.cli.log(`Dockerized Rust build encountered an error: ${res.error} ${res.status}.`);
         throw new Error(res.error);


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
-->

## What did you implement:

issues like https://github.com/softprops/serverless-rust/issues/19 and https://github.com/softprops/lambda-rust/issues/2 have indicated that assumptions about using a find command in a container to discover executables on window os'es can be problematic even with docker. 

as an alternative strategy we can leverage this plugins knowledge of the binary name to provide an explicit hint to the containerized builder which binary to package. this is just a prep pr pending the release of the next version of lambda-rust which will include a hook to take advantage of that hook.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

#### What (if anything) would need to be called out in the CHANGELOG for the next release: