### PR TITLE
Respect CARGO_HOME environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,9 +51,9 @@ class RustPlugin {
   }
 
   runDocker(funcArgs, cargoPackage, binary) {
-    const home = homedir();
-    const cargoRegistry = path.join(home, ".cargo/registry");
-    const cargoDownloads = path.join(home, ".cargo/git");
+    const cargoHome = process.env.CARGO_HOME || (path.join(homedir(), ".cargo"));
+    const cargoRegistry = path.join(cargoHome, "registry");
+    const cargoDownloads = path.join(cargoHome, "git");
     const defaultArgs = [
       'run',
       '--rm',


### PR DESCRIPTION
I couldn't see a convenient way of testing this automatically, but I verified it manually by setting `CARGO_HOME` and logging  the value of `defaultArgs` in `runDocker()`.

Fixes: #45 