### PR TITLE
feat: add the capability to override the docker cli and arguments

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -33,7 +33,7 @@ for project in  test-func test-func-dev; do
     unzip -o  \
         target/lambda/"${target}"/test-func.zip \
         -d /tmp/lambda > /dev/null 2>&1 && \
-    docker run \
+    ${SLS_DOCKER_CLI:-docker} run \
         -i --rm \
         -e DOCKER_LAMBDA_USE_STDIN=1 \
         -v /tmp/lambda:/var/task \


### PR DESCRIPTION
In environments that don't provide the `docker` command, or in which it is on a different path, the variable `SLS_DOCKER_CLI` can be used to override the default, and the `SLS_DOCKER_ARGS` can be used to set additional parameters for the `run` subcommand as needed.

For example, in environments which provide `podman` instead:

```
$ SLS_DOCKER_CLI=podman serverless invoke ...
```