### PR TITLE
Add configuration setting to specify docker image

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const { homedir } = require("os");
 const path = require("path");
 
 const DEFAULT_DOCKER_TAG = "0.2.6-rust-1.39.0";
+const DEFAULT_DOCKER_IMAGE = "softprops/lambda-rust";
 const RUST_RUNTIME = "rust";
 const BASE_RUNTIME = "provided";
 const NO_OUTPUT_CAPTURE = { stdio: ["ignore", process.stdout, process.stderr] };
@@ -36,7 +37,8 @@ class RustPlugin {
     this.custom = Object.assign(
       {
         cargoFlags: "",
-        dockerTag: DEFAULT_DOCKER_TAG
+        dockerTag: DEFAULT_DOCKER_TAG,
+        dockerImage: DEFAULT_DOCKER_IMAGE
       },
       (this.serverless.service.custom && this.serverless.service.custom.rust) ||
         {}
@@ -88,11 +90,12 @@ class RustPlugin {
       customArgs.push('-e', `CARGO_FLAGS=${cargoFlags}`);
     }
     const dockerTag = (funcArgs || {}).dockerTag || this.custom.dockerTag;
+    const dockerImage = (funcArgs || {}).dockerImage || this.custom.dockerImage;
 
     const finalArgs = [
       ...defaultArgs,
       ...customArgs,
-      `softprops/lambda-rust:${dockerTag}`
+      `${dockerImage}:${dockerTag}`
     ].filter(i => i);
 
     this.serverless.cli.log(


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
-->

## What did you implement:

Added the ability to specify the docker image name with the `custom.rust.dockerImage` variable.  If not provided, the previous default of `softprops/lambda-rust` is used.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #42

#### How did you verify your change:

- Verified that specifying the `dockerTag` and `dockerImage` in `serverless.yml` file causes docker to pull the correct image
- Verified the absence of the above tags causes docker to pull the default image

#### What (if anything) would need to be called out in the CHANGELOG for the next release: