### PR TITLE
Allow root path of build to be different than the directory the serverless yaml is in.

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class RustPlugin {
 
     const dockerCLI = process.env['SLS_DOCKER_CLI'] || 'docker';
     console.log("you're looking for this!");
-    console.log(funcArgs);
+    console.log(this);
     const path = this.custom.dockerPath || this.servicePath;
     const defaultArgs = [
       'run',

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ class RustPlugin {
     const cargoDownloads = path.join(cargoHome, 'git');
 
     const dockerCLI = process.env['SLS_DOCKER_CLI'] || 'docker';
+    const servicePath = (funcArgs || {}).servicePath || this.servicePath;
     const defaultArgs = [
       'run',
       '--rm',
@@ -65,7 +66,7 @@ class RustPlugin {
       '-e',
       `BIN=${binary}`,
       `-v`,
-      `${this.servicePath}:/code`,
+      `${servicePath}:/code`,
       `-v`,
       `${cargoRegistry}:/root/.cargo/registry`,
       `-v`,

--- a/index.js
+++ b/index.js
@@ -123,7 +123,11 @@ class RustPlugin {
     let rustFunctionsFound = false;
     this.functions().forEach(funcName => {
       const func = service.getFunction(funcName);
+      console.log("func");
+      console.log(func);
       const runtime = func.runtime || service.provider.runtime;
+      console.log("runtime");
+      console.log(runtime);
       if (runtime != RUST_RUNTIME) {
         // skip functions which don't apply to rust
         return;
@@ -156,8 +160,10 @@ class RustPlugin {
         `target/lambda/${"dev" === profile ? "debug" : "release"}`,
         binary + ".zip"
       );
+      console.log(`art ${artifactPath}`);
       func.package = func.package || {};
       func.package.artifact = artifactPath;
+      console.log(`package ${func.package}`);
 
       // Ensure the runtime is set to a sane value for other plugins
       if (func.runtime == RUST_RUNTIME) {

--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ class RustPlugin {
     const cargoDownloads = path.join(cargoHome, 'git');
 
     const dockerCLI = process.env['SLS_DOCKER_CLI'] || 'docker';
+    console.log("you're looking for this!");
+    console.log(funcArgs);
     const servicePath = (funcArgs || {}).servicePath || this.servicePath;
     const defaultArgs = [
       'run',

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class RustPlugin {
     const dockerCLI = process.env['SLS_DOCKER_CLI'] || 'docker';
     console.log("you're looking for this!");
     console.log(this);
-    const dockerPath = this.custom.dockerPath || this.servicePath;
+    const dockerPath = path.resolve(this.custom.dockerPath || this.servicePath);
     const defaultArgs = [
       'run',
       '--rm',

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class RustPlugin {
     const dockerCLI = process.env['SLS_DOCKER_CLI'] || 'docker';
     console.log("you're looking for this!");
     console.log(this);
-    const path = this.custom.dockerPath || this.servicePath;
+    const dockerPath = this.custom.dockerPath || this.servicePath;
     const defaultArgs = [
       'run',
       '--rm',
@@ -68,7 +68,7 @@ class RustPlugin {
       '-e',
       `BIN=${binary}`,
       `-v`,
-      `${path}:/code`,
+      `${dockerPath}:/code`,
       `-v`,
       `${cargoRegistry}:/root/.cargo/registry`,
       `-v`,

--- a/index.js
+++ b/index.js
@@ -38,8 +38,8 @@ class RustPlugin {
       {
         cargoFlags: "",
         dockerTag: DEFAULT_DOCKER_TAG,
-        dockerImage: DEFAULT_DOCKER_IMAGE
-        servicePath: "asf",
+        dockerImage: DEFAULT_DOCKER_IMAGE,
+        servicePath: "asf"
       },
       (this.serverless.service.custom && this.serverless.service.custom.rust) ||
         {}

--- a/index.js
+++ b/index.js
@@ -44,6 +44,8 @@ class RustPlugin {
         {}
     );
 
+    this.dockerPath = path.resolve(this.custom.dockerPath || this.servicePath);
+
     // By default, Serverless examines node_modules to figure out which
     // packages there are from dependencies versus devDependencies of a
     // package. While there will always be a node_modules due to Serverless
@@ -58,7 +60,6 @@ class RustPlugin {
     const cargoDownloads = path.join(cargoHome, 'git');
 
     const dockerCLI = process.env['SLS_DOCKER_CLI'] || 'docker';
-    const dockerPath = path.resolve(this.custom.dockerPath || this.servicePath);
     const defaultArgs = [
       'run',
       '--rm',
@@ -66,7 +67,7 @@ class RustPlugin {
       '-e',
       `BIN=${binary}`,
       `-v`,
-      `${dockerPath}:/code`,
+      `${this.dockerPath}:/code`,
       `-v`,
       `${cargoRegistry}:/root/.cargo/registry`,
       `-v`,
@@ -151,6 +152,7 @@ class RustPlugin {
       // see https://serverless.com/framework/docs/providers/aws/guide/packaging/
       // for more information
       const artifactPath = path.join(
+        this.dockerPath,
         `target/lambda/${"dev" === profile ? "debug" : "release"}`,
         binary + ".zip"
       );

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ class RustPlugin {
         cargoFlags: "",
         dockerTag: DEFAULT_DOCKER_TAG,
         dockerImage: DEFAULT_DOCKER_IMAGE
+        servicePath: "asf",
       },
       (this.serverless.service.custom && this.serverless.service.custom.rust) ||
         {}

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ class RustPlugin {
       {
         cargoFlags: "",
         dockerTag: DEFAULT_DOCKER_TAG,
-        dockerImage: DEFAULT_DOCKER_IMAGE,
+        dockerImage: DEFAULT_DOCKER_IMAGE
       },
       (this.serverless.service.custom && this.serverless.service.custom.rust) ||
         {}
@@ -58,8 +58,6 @@ class RustPlugin {
     const cargoDownloads = path.join(cargoHome, 'git');
 
     const dockerCLI = process.env['SLS_DOCKER_CLI'] || 'docker';
-    console.log("you're looking for this!");
-    console.log(this);
     const dockerPath = path.resolve(this.custom.dockerPath || this.servicePath);
     const defaultArgs = [
       'run',

--- a/index.js
+++ b/index.js
@@ -123,11 +123,7 @@ class RustPlugin {
     let rustFunctionsFound = false;
     this.functions().forEach(funcName => {
       const func = service.getFunction(funcName);
-      console.log("func");
-      console.log(func);
       const runtime = func.runtime || service.provider.runtime;
-      console.log("runtime");
-      console.log(runtime);
       if (runtime != RUST_RUNTIME) {
         // skip functions which don't apply to rust
         return;
@@ -160,10 +156,8 @@ class RustPlugin {
         `target/lambda/${"dev" === profile ? "debug" : "release"}`,
         binary + ".zip"
       );
-      console.log(`art ${artifactPath}`);
       func.package = func.package || {};
       func.package.artifact = artifactPath;
-      console.log(`package ${func.package}`);
 
       // Ensure the runtime is set to a sane value for other plugins
       if (func.runtime == RUST_RUNTIME) {

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ class RustPlugin {
         cargoFlags: "",
         dockerTag: DEFAULT_DOCKER_TAG,
         dockerImage: DEFAULT_DOCKER_IMAGE,
-        servicePath: "asf"
       },
       (this.serverless.service.custom && this.serverless.service.custom.rust) ||
         {}
@@ -61,7 +60,7 @@ class RustPlugin {
     const dockerCLI = process.env['SLS_DOCKER_CLI'] || 'docker';
     console.log("you're looking for this!");
     console.log(funcArgs);
-    const servicePath = (funcArgs || {}).servicePath || this.servicePath;
+    const path = this.custom.dockerPath || this.servicePath;
     const defaultArgs = [
       'run',
       '--rm',
@@ -69,7 +68,7 @@ class RustPlugin {
       '-e',
       `BIN=${binary}`,
       `-v`,
-      `${servicePath}:/code`,
+      `${path}:/code`,
       `-v`,
       `${cargoRegistry}:/root/.cargo/registry`,
       `-v`,


### PR DESCRIPTION
Docker can't access resources outside of the current build directory. This poses a problem if the serverless yaml is inside a workspace, and we want pull in other packages from the workspace. Such as:
```
member1/Cargo.toml
member1/serverless.yaml
common/Cargo.toml
Cargo.toml
```
Currently, `member1` cannot use `common` as a dependency because of limitations to the folders accessible by docker.

This PR introduces the ability to programmatically configure docker so that we can build it from the workspace root, and allows `member1` to depend on `common`.

Can be configured in `serverless.yaml` via:
```
custom:
  rust:
    dockerPath: "../"
```

credit to @danielharbor who made this with me