### PR TITLE
Fixes Dockerless build fails to run in Linux #76

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ class RustPlugin {
       "bootstrap",
       readFileSync(path.join(sourceDir, binary)),
       "",
-      755
+      0o755 <<16
     );
     const targetDir = this.localArtifactDir(profile);
     try {


### PR DESCRIPTION
## What did you implement:

Closes: #76 

#### How did you verify your change:

Ran it on my own function which originated the bug

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Nothing

Short note:
* code was trying to set attributes to the zip file to 755 rather than 0o755 aka 493 (unix permissions are useuallt expressed in octal)
* file permissions in Admzip need to be shifted 16 bits. Not documented, but I found out in stackoverflow and is confirmed by admzip [sources](https://github.com/cthackers/adm-zip/blob/master/adm-zip.js):
![image](https://user-images.githubusercontent.com/2453277/86328445-b8a37080-bc3c-11ea-9b4b-d9fa0125146e.png)
