### PR TITLE
add hooks for serverless-offline support

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ class RustPlugin {
     this.hooks = {
       "before:package:createDeploymentArtifacts": this.build.bind(this),
       "before:deploy:function:packageFunction": this.build.bind(this),
+      "before:offline:start": this.build.bind(this),
+      "before:offline:start:init": this.build.bind(this),
     };
     if (includeInvokeHook(serverless.version)) {
       this.hooks["before:invoke:local:invoke"] = this.build.bind(this);

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -26,6 +26,8 @@ describe("RustPlugin", () => {
     assert.deepEqual(Object.keys(plugin.hooks), [
       "before:package:createDeploymentArtifacts",
       "before:deploy:function:packageFunction",
+      "before:offline:start",
+      "before:offline:start:init",
     ]);
   });
   it("sets sensible defaults", () => {


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
-->

## What did you implement:

a story for testing lambdas locally easily still does not exist. serverless-offline is the defacto starndard for that in the serverless community. there are some hooks this plugin could add to make this easier

relates to https://github.com/softprops/serverless-rust/issues/74

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #xxx

#### How did you verify your change:

#### What (if anything) would need to be called out in the CHANGELOG for the next release: