### PR TITLE
Updated base runtime to `provided.al2`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const { mkdirSync, writeFileSync, readFileSync } = require("fs");
 const DEFAULT_DOCKER_TAG = "latest";
 const DEFAULT_DOCKER_IMAGE = "softprops/lambda-rust";
 const RUST_RUNTIME = "rust";
-const BASE_RUNTIME = "provided";
+const BASE_RUNTIME = "provided.al2";
 const NO_OUTPUT_CAPTURE = { stdio: ["ignore", process.stdout, process.stderr] };
 const MUSL_PLATFORMS = ["darwin", "win32", "linux"];
 


### PR DESCRIPTION
## What did you implement:

Use Amazon Linux 2 as base OS

Closes: #83 

#### How did you verify your change: I ran unit and integration tests.  However, I also tried `provided.al3` (which isn't a thing) and that passed tests.  So I don't have full confidence that the existing tests cover the base-runtime.  I don't know enough about custom Lambda runtimes to know exactly what needs to change in the tests.

#### What (if anything) would need to be called out in the CHANGELOG for the next release: