### PR TITLE
Update adm-zip version to avoid dockerless permission error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1015,7 +1015,6 @@
         "@serverless/platform-client": "^0.25.7",
         "@serverless/platform-client-china": "^1.0.12",
         "@serverless/platform-sdk": "^2.3.0",
-        "adm-zip": "^0.4.14",
         "ansi-escapes": "^4.3.1",
         "axios": "^0.19.2",
         "chalk": "^2.4.2",
@@ -1216,7 +1215,6 @@
       "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-0.25.14.tgz",
       "integrity": "sha512-ww5GBt5QEHYppLH8X+gEFiuMoFu9xdXK0bEROYbuxUliiB0IfXTXLzWR5whhi/S94R7pTnJ4O+WUiFj0PcV/tQ==",
       "requires": {
-        "adm-zip": "^0.4.13",
         "axios": "^0.19.2",
         "https-proxy-agent": "^5.0.0",
         "isomorphic-ws": "^4.0.1",
@@ -1668,9 +1666,10 @@
       "dev": true
     },
     "adm-zip": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
-      "integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.1.tgz",
+      "integrity": "sha512-a5ABmIFUJ9OxHV5zrXM9Q41JzpRIflFtdgpL4UQM9DsTHHxQzPRaeyAdnMW7kxL0NRWm/NHafJdj6pO+ty7L2g==",
+      "dev": true
     },
     "after": {
       "version": "0.8.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "serverless": "^1.71.3"
   },
   "devDependencies": {
-    "adm-zip": "^0.4.14",
+    "adm-zip": "^0.5.1",
     "jest": "^26.0.1",
     "jest-circus": "^26.0.1",
     "prettier": "^2.0.5"


### PR DESCRIPTION
ADM-ZIP v0.4.14 library does not respect file permissions in addFile() method (probably a bug). The bootstrap binary file ends up with no x permission. Updating to ADM-ZIP v0.5.1 fixes the problem.

<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
-->

## What did you implement:
Update of **adm-zip** in _package.json_ (that also means changes in _package-lock.json_ file).

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #93

#### How did you verify your change:
Local invokes with **dockerless: true** now succeed.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
Could mention update of **adm-zip** from _v0.4.14_ to _v0.5.1_ (probably not necessary)