### PR TITLE
Support building for al2 with GNU + glibc 2.26

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class RustPlugin {
       ""
     ).split(/\s+/);
     const targetArgs = MUSL_PLATFORMS.includes(platform)
-      ? ["--target", "x86_64-unknown-linux-musl"]
+      ? ["--target", "x86_64-unknown-linux-gnu"]
       : [];
     return [
       ...defaultArgs,
@@ -96,9 +96,9 @@ class RustPlugin {
         : "darwin" === platform
         ? {
             RUSTFLAGS:
-              (env["RUSTFLAGS"] || "") + " -Clinker=x86_64-linux-musl-gcc",
-            TARGET_CC: "x86_64-linux-musl-gcc",
-            CC_x86_64_unknown_linux_musl: "x86_64-linux-musl-gcc",
+              (env["RUSTFLAGS"] || "") + " -Clinker=x86_64-linux-gnu-gcc",
+            TARGET_CC: "x86_64-linux-gnu-gcc",
+            CC_x86_64_unknown_linux_musl: "x86_64-linux-gnu-gcc",
           }
         : {};
     return {
@@ -110,7 +110,7 @@ class RustPlugin {
   localSourceDir(profile, platform) {
     let executable = "target";
     if (MUSL_PLATFORMS.includes(platform)) {
-      executable = path.join(executable, "x86_64-unknown-linux-musl");
+      executable = path.join(executable, "x86_64-unknown-linux-gnu");
     }
     return path.join(executable, profile !== "dev" ? "release" : "debug");
   }


### PR DESCRIPTION
## What did you implement: 
I modified the build script to invoke the compiler for GNU instead of MUSL, with inspiration from [here](https://umccr.org/blog/aws-bioinformatics-rust/) and [here](https://andygrove.io/2020/05/why-musl-extremely-slow/). glibc 2.26 must be available locally.

#### How did you verify your change: 
I built and deployed an app to lambda with al2 that was compiled with these changes.

#### What (if anything) would need to be called out in the CHANGELOG for the next release:
We'd need a way to switch the target args, rust flags, and chosen compiler executable between MUSL and GNU.