### PR TITLE
Fix file permissions when zipping

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ class RustPlugin {
       "bootstrap",
       readFileSync(path.join(sourceDir, binary)),
       "",
-      755
+      0x755 << 16
     );
     const targetDir = this.localArtifactDir(profile);
     try {


### PR DESCRIPTION
## What did you implement:

Set the correct attributes when zipping the build. After this fix the output from `unzip -Zv my-build.zip` is:

```
  non-MSDOS external file attributes:             075500 hex
  MS-DOS file attributes (00 hex):                none
```

Should fix: #102

#### How did you verify your change:

I can now run my function locally on MacOs.