### PR TITLE
Fixed permissions for local build

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ class RustPlugin {
       "bootstrap",
       readFileSync(path.join(sourceDir, binary)),
       "",
-      0o755
+      "755"
     );
     const targetDir = this.localArtifactDir(profile);
     try {


### PR DESCRIPTION
This PR is about changing permissions for the built bootstrap file.

In the last released tag (https://github.com/softprops/serverless-rust/releases/tag/v0.3.8) integer `755` value is used https://github.com/softprops/serverless-rust/blob/c17cb6c380ee6ca5cbf441ac9df718a7325be13c/index.js#L152 Which is incorrect.

In the latest master octal `0o755 ` value is used: https://github.com/softprops/serverless-rust/blob/master/index.js#L172 

But this also causes some issues. Ways to reproduce:
1. Clone https://github.com/SerheyDolgushev/serverless-rust-example
2. Run `hello` rust lambda function:
    ```bash
    npx serverless invoke local -f hello
    ```
3. Try to unzip `target/lambda/release/lambda.zip` using `unzip` command:
    ```bash
    unzip target/lambda/release/lambda.zip 
    Archive:  target/lambda/release/lambda.zip
       skipping: bootstrap               volume label
    ```
4. It is still possible to unzip `target/lambda/release/lambda.zip` just by double-clicking on it. But extracted `bootstrap` will have wrong permissions in this case (`-r--r--r--` so execute permission is missing):
    ```bash
    ls -l target/lambda/release/bootstrap 
    -r--r--r--  1 sdolgushev  72107521  6765776 Mar 25 09:32 target/lambda/release/bootstrap
    ```

The issue is fixed with this PR.