### PR TITLE
fix: use `tags` instead of a custom invalid `runtime` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,6 @@ const { mkdirSync, writeFileSync, readFileSync } = require("fs");
 
 const DEFAULT_DOCKER_TAG = "latest";
 const DEFAULT_DOCKER_IMAGE = "softprops/lambda-rust";
-const RUST_RUNTIME = "rust";
-const BASE_RUNTIME = "provided.al2";
 const NO_OUTPUT_CAPTURE = { stdio: ["ignore", process.stdout, process.stderr] };
 const MUSL_PLATFORMS = ["darwin", "win32", "linux"];
 
@@ -77,7 +75,7 @@ class RustPlugin {
 
     let target = (funcArgs || {}).target || this.custom.target
 
-    const targetArgs = 
+    const targetArgs =
       target ?
         ['--target', target]
         : MUSL_PLATFORMS.includes(platform)
@@ -288,8 +286,8 @@ class RustPlugin {
     let rustFunctionsFound = false;
     this.functions().forEach((funcName) => {
       const func = service.getFunction(funcName);
-      const runtime = func.runtime || service.provider.runtime;
-      if (runtime != RUST_RUNTIME) {
+      const isRustFunction = !!func.tags?.rust
+      if (!isRustFunction) {
         // skip functions which don't apply to rust
         return;
       }
@@ -324,19 +322,11 @@ class RustPlugin {
       );
       func.package = func.package || {};
       func.package.artifact = artifactPath;
-
-      // Ensure the runtime is set to a sane value for other plugins
-      if (func.runtime == RUST_RUNTIME) {
-        func.runtime = BASE_RUNTIME;
-      }
     });
-    if (service.provider.runtime === RUST_RUNTIME) {
-      service.provider.runtime = BASE_RUNTIME;
-    }
     if (!rustFunctionsFound) {
       throw new Error(
         `Error: no Rust functions found. ` +
-          `Use 'runtime: ${RUST_RUNTIME}' in global or ` +
+          `Use 'tags.rust: true' in ` +
           `function configuration to use this plugin.`
       );
     }


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
-->

## What did you implement:

Serverless 3 will throw an error if we use a `provider.runtime` option different from the allowed values:

```
Error:
Configuration error at 'provider.runtime': must be equal to one of the allowed values [dotnet6, dotnetcore3.1, go1.x, java11, java8, java8.al2, nodejs12.x, nodejs14.x, nodejs16.x, provided, provided.al2, python3.6, python3.7, python3.8, python3.9, ruby2.7]

Learn more about configuration validation here: http://slss.io/configuration-validation
```

This PR removes the need to use the new runtime option (`rust`) and uses `tags.rust: true` inside the function configuration.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #107

#### How did you verify your change:

Just put a `tag.rust: true` in your function configuration and run `npx serverless package`:

```yml
functions:
  rust:
    handler: your_rust_project_name
    runtime: provided.al2
    tags:
      rust: true
```

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

You can use the title of this PR.

@softprops =)