### PR TITLE
feat: support builds from a cargo workspace

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ class RustPlugin {
         dockerTag: DEFAULT_DOCKER_TAG,
         dockerImage: DEFAULT_DOCKER_IMAGE,
         dockerless: false,
+        inWorkspace: false,
       },
       (this.serverless.service.custom && this.serverless.service.custom.rust) ||
         {}
@@ -167,7 +168,7 @@ class RustPlugin {
     const zip = new AdmZip();
     zip.addFile(
       "bootstrap",
-      readFileSync(path.join(sourceDir, binary)),
+      readFileSync(path.join(this.custom.inWorkspace ? '..' : '', sourceDir, binary)),
       "",
       0o755
     );

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -40,6 +40,7 @@ describe("RustPlugin", () => {
       dockerImage: "softprops/lambda-rust",
       dockerTag: "latest",
       dockerless: false,
+      inWorkspace: false
     });
   });
 
@@ -54,6 +55,7 @@ describe("RustPlugin", () => {
               dockerImage: "notsoftprops/lambda-rust",
               dockerTag: "custom-tag",
               dockerless: true,
+              inWorkspace: false
             },
           },
           package: {},
@@ -67,6 +69,7 @@ describe("RustPlugin", () => {
       dockerImage: "notsoftprops/lambda-rust",
       dockerTag: "custom-tag",
       dockerless: true,
+      inWorkspace: false
     });
   });
 


### PR DESCRIPTION
## What did you implement:

Adds a new custom flag to signal that the serverless.yml is nested in a cargo [workspace](https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html). Since the binaries will be outputted to a target folder in the workspace root, the zip-copy-process needs to take that into account.

Not sure if this is the most appropriate change; however, it solved my problem.

> I want to be able to separate the lambda-projects to isolate different dependencies etc.

```yml
custom:
  rust:
    dockerless: true
    inWorkspace: true # <---- Defaults to false
```

#### How did you verify your change:
Deployed multiple stacks from the workspace root to AWS using serverless components.

```bash
.
├── Cargo.lock
├── Cargo.toml
├── shared-infra
│   └── serverless.yml
├── package.json
├── package-lock.json
├── lambda1 # rest api
│   ├── Cargo.toml
│   ├── serverless.yml
│   ├── src
│   │   ├── handler.rs
│   │   └── main.rs
│   └── target
│       └── lambda
│           └── release
│               └── lambda1.zip
├── lambda2 # queue-consumer
│   ├── Cargo.toml
│   ├── serverless.yml
│   ├── src
│   │   ├── handler.rs
│   │   ├── main.rs
│   │   └── messages.rs
│   └── target
│       └── lambda
│           └── release
│               └── lambda2.zip
├── serverless-compose.yml
├── target
│   ├── release
│   └── x86_64-unknown-linux-musl
│       └── release
│           ├── lambda1
│           ├── lambda1.d
│           ├── lambda2
│           └── lambda2.d
└── yarn.lock

```
